### PR TITLE
sync with latest btex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.3.16
+
+- Bump btex version.
+- Implement `\includegraphics`
+
 ## 0.3.15
 
 - Upstream problems.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ configuration, you can either print or export to PDF.
 - [X] Inverse search.
 - [X] Compiles the bTeX file and show the preview on save.
 - [X] Exports the result to PDF or printer.
+- [X] Use `\includegraphics{relative path}` to include graphics in the workspace folder. Weblinks and base64-encoded URIs are also accepted.
 
 ## Requirements
 
@@ -33,6 +34,7 @@ configuration, you can either print or export to PDF.
   - If you cannot render tikz pictures, check out which process is using the 9292 port, either terminate it or convince it to use another port instead.
 - Wiki templates do not work, because they are stored on wiki servers. I'm not going to implement local wiki templates either. Similarly wiki-style links will show up as blue but don't link anywhere. This means that images (which currently uses MediaWiki syntax) doesn't work. I might try to implement that, or I can get some separate image mechanics in.
 - Collapsible proofs do not work (yet) because it requires more javascript machinery.
-- Currently the released version uses a custom version of bananaTeX not recorded in `package.json` because the PR hasn't been merged yet, will fix when merged.
+- `\includegraphics` doesn't work in formulas.
+- Inverse search doesn't work with graphics. A workaround is to click on elements close to them, e.g. captions.
 
 ## Release Notes

--- a/package.json
+++ b/package.json
@@ -116,10 +116,10 @@
     "devDependencies": {
         "@types/glob": "^8.0.0",
         "@types/katex": "^0.14.0",
-        "@types/yargs": "^17.0.15",
         "@types/mocha": "^9.1.1",
         "@types/node": "16.x",
         "@types/vscode": "^1.68.0",
+        "@types/yargs": "^17.0.15",
         "@typescript-eslint/eslint-plugin": "^5.27.0",
         "@typescript-eslint/parser": "^5.27.0",
         "@vscode/test-electron": "^2.1.3",
@@ -129,6 +129,6 @@
         "typescript": "^4.7.2"
     },
     "dependencies": {
-        "btex": "banana-space/btex.git#685c9548645022506a601e62ee25d6914e2c8433"
+        "btex": "github:banana-space/btex#7bcbc97b98d2cdbc21aa375295bfc2450c73cc1c"
     }
 }

--- a/src/PanelManager.ts
+++ b/src/PanelManager.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
 import { serve } from './ServePrinting';  // Actually lazy loaded
+import { Buffer } from 'buffer';
 import { runWorker } from 'btex';
 var _runWorker : typeof runWorker;
 var _serve : typeof serve;
@@ -89,6 +91,7 @@ async function gotoPosition(doc: vscode.TextDocument, col: vscode.ViewColumn, po
 
 export class PanelManager implements vscode.Disposable {
     readonly doc: vscode.TextDocument;
+    readonly workspaceFolder: string;
     readonly viewColumn: vscode.ViewColumn;
     readonly panel: vscode.WebviewPanel;
     private static _isInvertAll : boolean = false;
@@ -100,6 +103,7 @@ export class PanelManager implements vscode.Disposable {
     constructor(editor: vscode.TextEditor) {
         this.viewColumn = editor.viewColumn ?? vscode.ViewColumn.Beside;
         this.doc = editor.document;
+        this.workspaceFolder = vscode.workspace.workspaceFolders? vscode.workspace.workspaceFolders[0].uri.path : "/";
         this.panel = vscode.window.createWebviewPanel(
             'bTeXpreview',
             'Preview bTeX',
@@ -107,7 +111,10 @@ export class PanelManager implements vscode.Disposable {
             {
                 localResourceRoots: [
                     vscode.Uri.file(
-                        path.join(PanelManager.extensionPath, 'resources'))
+                        path.join(PanelManager.extensionPath, 'resources')),
+                    vscode.Uri.file(
+                        this.workspaceFolder
+                    )
                 ],
                 enableScripts: true
             }
@@ -133,7 +140,7 @@ export class PanelManager implements vscode.Disposable {
                 htmlTitle ?: string,
                 displayTitle ?: string
             } = JSON.parse(result.data);
-            const diagnostics = [];
+            const diagnostics : vscode.Diagnostic[]=[];
             for (const err of result.errors) {
                 // code:LINE:COL MSG
                 const res = /^code:([0-9]+):([0-9]+) (.*)$/.exec(err);
@@ -153,6 +160,37 @@ export class PanelManager implements vscode.Disposable {
             PanelManager.diags.set(this.doc.uri, diagnostics);
             // This guard prevents the contents from emptying.
             if (result.html !== '' || result.errors.length === 0) {
+                let img_replacer = (match:string, opt:string, src:string, offset:any, string:any, group:any) => {
+                    console.log(src)
+                    let new_src = "";
+                    if(/^https?:\/\/\w/.test(src) || /^data:image\/(\w);base64/.test(src))
+                    {
+                        // web image or inline image
+                        new_src = src;
+                    }
+                    else if(/^(\w+\\)*.\w/.test(src))
+                    {
+                        // TODO add image extension verification and error handling
+                        // relative dir
+                        if(printing)
+                        {
+                            let dir = path.join(this.workspaceFolder, src);
+                            let ext = path.extname(dir).substring(1);
+                            let base64Image = "";
+                            let buf:Buffer = fs.readFileSync(dir);
+                            base64Image = buf.toString('base64');
+                            new_src = `data:image/${ext};base64,${base64Image}`; 
+                        }
+                        else {
+                            new_src = this.panel.webview.asWebviewUri(vscode.Uri.file(path.join(this.workspaceFolder, src))).toString();
+                        }
+                    }
+                    return `<img${opt}src="${new_src}"`;
+                }
+                const img_regex = /<img(.*?)src="(.*?)"/g;
+                let new_html = result.html.replace(img_regex, img_replacer);
+                result.html = new_html;
+
                 if (printing) {
                     const html = `<!DOCTYPE html>
 <head>

--- a/src/PanelManager.ts
+++ b/src/PanelManager.ts
@@ -163,7 +163,7 @@ export class PanelManager implements vscode.Disposable {
                 let img_replacer = (match:string, opt:string, src:string, offset:any, string:any, group:any) => {
                     console.log(src)
                     let new_src = "";
-                    if(/^https?:\/\/\w/.test(src) || /^data:image\/(\w);base64/.test(src))
+                    if(/^https?:\/\/\w/.test(src) || /^data:image\/(.*);base64/.test(src))
                     {
                         // web image or inline image
                         new_src = src;

--- a/src/PanelManager.ts
+++ b/src/PanelManager.ts
@@ -1,13 +1,15 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { serve } from './ServePrinting';  // Actually lazy loaded
+// Type only imports
 import { Buffer } from 'buffer';
+// Lazy loaded imports
+import { serve } from './ServePrinting';
 import { runWorker } from 'btex';
 var _runWorker : typeof runWorker;
 var _serve : typeof serve;
 
-const PREAMBLE = ''; // TODO
+const PREAMBLE = '\\enableincludegraphics'; // TODO
 const COMPILER_SETTINGS = {  // compiler options
     maxErrors: 100,
     maxMacroExpansions: 50000,


### PR DESCRIPTION
The only feature that requires modification in this extension is enable \includegraphics
To test, add `\enableincludegraphics` to preamable. 

web-origined image or base64 encoded image will be displayed directly

images in the workspaceFolder of vscode can only be imported with relative path and it will be displayed in  vscode(using webview) and in printing browser(using base64)

after updating the latest btex, we have to go to `node_modules/btex` to run build there before we build the extension.

reverse link of image/table is currently not supported, some modification in btex is necessary

